### PR TITLE
Update alert styles to match new UX pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-bootstrap",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "The Bootstrap theme for Open edX",
   "license": "Apache-2.0",
   "repository": {

--- a/samples/edx/course.html
+++ b/samples/edx/course.html
@@ -33,8 +33,16 @@
                 <a class="dropdown-item" href="#">Sign Out</a>
             </div>
         </div>
-
     </nav>
+
+    <div class="page-banner">
+        <div class="user-messages">
+            <div class="alert alert-warning" role="alert">
+                <span class="icon icon-alert fa fa-warning" aria-hidden="true"></span>
+                This is a sample warning message
+            </div>
+        </div>
+    </div>
 
     <ul class="nav nav-pills flex-column flex-sm-row mb-3">
         <li class="nav-item"><a class="nav-link" href="../index.html">Home</a></li>

--- a/samples/open-edx/course.html
+++ b/samples/open-edx/course.html
@@ -33,8 +33,16 @@
                 <a class="dropdown-item" href="#">Sign Out</a>
             </div>
         </div>
-
     </nav>
+
+    <div class="page-banner">
+        <div class="user-messages">
+            <div class="alert alert-warning" role="alert">
+                <span class="icon icon-alert fa fa-warning" aria-hidden="true"></span>
+                This is a sample warning message
+            </div>
+        </div>
+    </div>
 
     <ul class="nav nav-pills flex-column flex-sm-row mb-3">
         <li class="nav-item"><a class="nav-link" href="../index.html">Home</a></li>

--- a/sass/edx/_variables.scss
+++ b/sass/edx/_variables.scss
@@ -645,22 +645,21 @@ $nav-tabs-justified-active-link-border-color: transparent !default;
 //
 // Define colors for form feedback states and, by default, alerts.
 
-$state-success-text:             $green !default;
-$state-success-bg:               $body-bg !default;
-$state-success-border:           $green !default;
+$state-success-text:               $black !default;
+//$state-success-bg:               #dff0d8 !default;
+//$state-success-border:           darken($state-success-bg, 5%) !default;
 
-$state-info-text:                $blue !default;
-$state-info-bg:                  $body-bg !default;
-$state-info-border:              $blue !default;
+$state-info-text:                  $black !default;
+//$state-info-bg:                  #d9edf7 !default;
+//$state-info-border:              darken($state-info-bg, 7%) !default;
 
-$state-warning-text:             $yellow !default;
-$state-warning-bg:               $body-bg !default;
-$mark-bg:                        $yellow !default;
-$state-warning-border:           $yellow !default;
+$state-warning-text:               $black !default;
+//$state-warning-bg:               #fcf8e3 !default;
+//$state-warning-border:           darken($state-warning-bg, 5%) !default;
 
-$state-danger-text:              $red !default;
-$state-danger-bg:                $body-bg !default;
-$state-danger-border:            $red !default;
+$state-danger-text:                $black !default;
+//$state-danger-bg:                #f2dede !default;
+//$state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
 // Cards
@@ -782,25 +781,25 @@ $state-danger-border:            $red !default;
 //$alert-padding-x:             1.25rem !default;
 //$alert-padding-y:             .75rem !default;
 //$alert-margin-bottom:         $spacer-y !default;
-$alert-border-radius:         0 !default;
+$alert-border-radius:         1px !default;
 //$alert-link-font-weight:      $font-weight-bold !default;
 //$alert-border-width:          $border-width !default;
 
-$alert-success-bg:            $body-bg !default;
-$alert-success-text:          $body-color !default;
-$alert-success-border:        $state-success-border !default;
+//$alert-success-bg:            $state-success-bg !default;
+//$alert-success-text:          $state-success-color !default;
+//$alert-success-border:        $state-success-border !default;
 
-$alert-info-bg:               $body-bg !default;
-$alert-info-text:             $body-color !default;
-$alert-info-border:           $state-info-border !default;
+//$alert-info-bg:               $state-info-bg !default;
+//$alert-info-text:             $state-info-color !default;
+//$alert-info-border:           $state-info-border !default;
 
-$alert-warning-bg:            $body-bg !default;
-$alert-warning-text:          $body-color !default;
-$alert-warning-border:        $state-warning-border !default;
+//$alert-warning-bg:            $state-warning-bg !default;
+//$alert-warning-text:          $state-warning-color !default;
+//$alert-warning-border:        $state-warning-border !default;
 
-$alert-danger-bg:             $body-bg !default;
-$alert-danger-text:           $body-color !default;
-$alert-danger-border:         $state-danger-border !default;
+//$alert-danger-bg:             $state-danger-bg !default;
+//$alert-danger-text:           $state-danger-color !default;
+//$alert-danger-border:         $state-danger-border !default;
 
 
 // Progress bars

--- a/sass/open-edx/_variables.scss
+++ b/sass/open-edx/_variables.scss
@@ -639,22 +639,21 @@ $nav-tabs-justified-active-link-border-color: transparent !default;
 //
 // Define colors for form feedback states and, by default, alerts.
 
-$state-success-text:             $green !default;
-$state-success-bg:               $body-bg !default;
-$state-success-border:           $green !default;
+$state-success-text:               $black !default;
+//$state-success-bg:               #dff0d8 !default;
+//$state-success-border:           darken($state-success-bg, 5%) !default;
 
-$state-info-text:                $blue !default;
-$state-info-bg:                  $body-bg !default;
-$state-info-border:              $blue !default;
+$state-info-text:                  $black !default;
+//$state-info-bg:                  #d9edf7 !default;
+//$state-info-border:              darken($state-info-bg, 7%) !default;
 
-$state-warning-text:             $yellow !default;
-$state-warning-bg:               $body-bg !default;
-$mark-bg:                        $yellow !default;
-$state-warning-border:           $yellow !default;
+$state-warning-text:               $black !default;
+//$state-warning-bg:               #fcf8e3 !default;
+//$state-warning-border:           darken($state-warning-bg, 5%) !default;
 
-$state-danger-text:              $red !default;
-$state-danger-bg:                $body-bg !default;
-$state-danger-border:            $red !default;
+$state-danger-text:                $black !default;
+//$state-danger-bg:                #f2dede !default;
+//$state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
 // Cards
@@ -776,25 +775,25 @@ $state-danger-border:            $red !default;
 //$alert-padding-x:             1.25rem !default;
 //$alert-padding-y:             .75rem !default;
 //$alert-margin-bottom:         $spacer-y !default;
-$alert-border-radius:         0 !default;
+$alert-border-radius:           1px !default;
 //$alert-link-font-weight:      $font-weight-bold !default;
 //$alert-border-width:          $border-width !default;
 
-$alert-success-bg:            $body-bg !default;
-$alert-success-text:          $body-color !default;
-$alert-success-border:        $state-success-border !default;
+//$alert-success-bg:            $state-success-bg !default;
+//$alert-success-text:          $state-success-color !default;
+//$alert-success-border:        $state-success-border !default;
 
-$alert-info-bg:               $body-bg !default;
-$alert-info-text:             $body-color !default;
-$alert-info-border:           $state-info-border !default;
+//$alert-info-bg:               $state-info-bg !default;
+//$alert-info-text:             $state-info-color !default;
+//$alert-info-border:           $state-info-border !default;
 
-$alert-warning-bg:            $body-bg !default;
-$alert-warning-text:          $body-color !default;
-$alert-warning-border:        $state-warning-border !default;
+//$alert-warning-bg:            $state-warning-bg !default;
+//$alert-warning-text:          $state-warning-color !default;
+//$alert-warning-border:        $state-warning-border !default;
 
-$alert-danger-bg:             $body-bg !default;
-$alert-danger-text:           $body-color !default;
-$alert-danger-border:         $state-danger-border !default;
+//$alert-danger-bg:             $state-danger-bg !default;
+//$alert-danger-text:           $state-danger-color !default;
+//$alert-danger-border:         $state-danger-border !default;
 
 
 // Progress bars


### PR DESCRIPTION
This change updates the edX Bootstrap alert styles to match the page banners recently added to the LMS with https://github.com/edx/edx-platform/pull/15570.

You can see a preview here (check out the course pages):

http://ux-test.edx.org/andya/alert-styles/

Here's a screenshot:

![image](https://user-images.githubusercontent.com/5985072/28350211-63826004-6c15-11e7-9580-4c0b0e02ba74.png)
