### PR TITLE
Move edx-bootstrap into the edX org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Getting Started
 
 The edx-bootstrap library should be installed via npm:
 
-    npm install --save edx-bootstrap
+    npm install --save @edx/edx-bootstrap
 
 Once installed, you can generate the `sample pages`_:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "edx-bootstrap",
-  "version": "0.2.1",
+  "name": "@edx/edx-bootstrap",
+  "version": "0.3.0",
   "description": "The Bootstrap theme for Open edX",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This is a simple change to move edx-bootstrap into the edX organization.