### PR TITLE
Separate build and local preview of samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@
 
 .DEFAULT_GOAL := help
 
+# Generates a help message. Borrowed from https://github.com/pydanny/cookiecutter-djangopackage.
 help: ## display this help message
 	@echo "Please use \`make <target>' where <target> is one of"
-	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
+	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
 install: ## install requirements
 	npm install

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ clean: ## remove build artifacts
 	rm -rf samples/css/
 	rm -rf samples/edx-bootstrap/
 
-samples: clean ## build the samples
+build: clean ## build the npm package
+
+build.samples: clean ## build the samples
 	mkdir samples/edx-bootstrap
 	cp -r sass/ samples/edx-bootstrap/sass
 	mkdir samples/css
@@ -22,11 +24,11 @@ samples: clean ## build the samples
 	mkdir samples/css/open-edx
 	./node_modules/node-sass/bin/node-sass samples/edx/sass --output samples/edx/css --include-path samples --include-path node_modules
 	./node_modules/node-sass/bin/node-sass samples/open-edx/sass --output samples/open-edx/css --include-path samples --include-path node_modules
+
+samples: clean build.samples ## build and show the samples
 	./node_modules/.bin/opn samples/index.html
 
-build: clean ## build the npm package
-
-preview: samples ## build the preview site
+preview: build.samples ## build the preview site
 	aws s3 sync samples s3://${S3_PREVIEW_DOMAIN}/$(shell git rev-parse --abbrev-ref HEAD)
 	@echo Preview generated to http://${S3_PREVIEW_DOMAIN}/$(shell git rev-parse --abbrev-ref HEAD)
 
@@ -36,7 +38,7 @@ quality:
 fix:
 	./node_modules/stylelint/bin/stylelint.js sass/**/*.scss samples/**/*.scss --fix
 
-test: clean quality ## run tests
+test: clean quality build.samples ## run tests
 
 xxx:
 	echo $(shell git rev-parse --abbrev-ref HEAD)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 .DEFAULT_GOAL := help
 
+NPM_BIN = $(shell npm bin)
+
 # Generates a help message. Borrowed from https://github.com/pydanny/cookiecutter-djangopackage.
 help: ## display this help message
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -11,33 +13,32 @@ install: ## install requirements
 	npm install
 
 clean: ## remove build artifacts
-	rm -rf css/
-	rm -rf samples/css/
-	rm -rf samples/edx-bootstrap/
+	rm -rf {css,samples/{css,edx-bootstrap}}
 
 build.samples: clean ## build the samples
-	mkdir samples/edx-bootstrap
-	cp -r sass/ samples/edx-bootstrap/sass
-	mkdir samples/css
-	mkdir samples/css/edx
-	mkdir samples/css/open-edx
-	./node_modules/node-sass/bin/node-sass samples/edx/sass --output samples/edx/css --include-path samples --include-path node_modules
-	./node_modules/node-sass/bin/node-sass samples/open-edx/sass --output samples/open-edx/css --include-path samples --include-path node_modules
+	$(eval $@_INCLUDE = --include-path samples --include-path node_modules)
+	mkdir -p samples/edx-bootstrap
+	mkdir -p samples/css/{edx,open-edx}
+	cp -R sass/ samples/edx-bootstrap/sass
+	$(NPM_BIN)/node-sass samples/edx/sass --output samples/edx/css $($@_INCLUDE)
+	$(NPM_BIN)/node-sass samples/open-edx/sass --output samples/open-edx/css $($@_INCLUDE)
 
 samples: clean build.samples ## build and show the samples
-	./node_modules/.bin/opn samples/index.html
+	$(NPM_BIN)/opn samples/index.html
 
 preview: build.samples ## build the preview site
-	aws s3 sync samples s3://${S3_PREVIEW_DOMAIN}/$(shell git rev-parse --abbrev-ref HEAD)
-	@echo Preview generated to http://${S3_PREVIEW_DOMAIN}/$(shell git rev-parse --abbrev-ref HEAD)
+	$(eval $@_REF = $(shell git rev-parse --abbrev-ref HEAD))
+	aws s3 sync samples s3://${S3_PREVIEW_DOMAIN}/$($@_REF)
+	@echo Preview generated to http://${S3_PREVIEW_DOMAIN}/$($@_REF)
+	$(NPM_BIN)/opn http://${S3_PREVIEW_DOMAIN}/$($@_REF)
 
 quality:
-	./node_modules/stylelint/bin/stylelint.js sass/**/*.scss samples/**/*.scss
+	$(NPM_BIN)/stylelint sass/**/*.scss samples/**/*.scss
 
 fix:
-	./node_modules/stylelint/bin/stylelint.js sass/**/*.scss samples/**/*.scss --fix
+	$(NPM_BIN)/stylelint sass/**/*.scss samples/**/*.scss --fix
 
 test: clean quality build.samples ## run tests
 
 xxx:
-	echo $(shell git rev-parse --abbrev-ref HEAD)
+	echo $$(git rev-parse --abbrev-ref HEAD)

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,6 @@ clean: ## remove build artifacts
 	rm -rf samples/css/
 	rm -rf samples/edx-bootstrap/
 
-build: clean ## build the npm package
-
 build.samples: clean ## build the samples
 	mkdir samples/edx-bootstrap
 	cp -r sass/ samples/edx-bootstrap/sass

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/edx-bootstrap",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Replaces #16.

* Rename `samples` → `build.samples`
* Add updated `samples` which opens the samples in a local browser
* Fix `help` so it works with dot namespaced target names
* Optimize tasks