### PR TITLE
Upgrade to the Bootstrap beta.2 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/edx-bootstrap",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -72,7 +72,7 @@
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
       "dev": true,
       "requires": {
         "color-convert": "1.9.0"
@@ -81,7 +81,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -125,7 +125,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "array-find-index": {
@@ -327,7 +327,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY=",
       "dev": true
     },
     "big.js": {
@@ -361,9 +361,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.0.0-beta",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.tgz",
-      "integrity": "sha512-I/r3fYtUZr+rUNkh8HI+twxZ56p6ehNn27eA1XSebLVQKAJ2xZHnEvZrSR+UR2A/bONcd9gHC3xatVhQlH6R6w=="
+      "version": "4.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.2.tgz",
+      "integrity": "sha512-DzGtdTlKbrMoGMpz0LigKSqJ+MgtFKxA791PU/q062OlRG0HybNZcTLH7rpDAmLS66Y3esN9yzKHLLbqa5UR3w=="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -407,7 +407,7 @@
     "browserslist": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.4.0.tgz",
-      "integrity": "sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ==",
+      "integrity": "sha1-aT7pPQHmZGimNI2lSY4BH1ePh/g=",
       "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000740",
@@ -490,7 +490,7 @@
     "chalk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
@@ -517,7 +517,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-cursor": {
@@ -668,7 +668,7 @@
     "cosmiconfig": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+      "integrity": "sha1-YXPOvVb6wELB9DkO33r2wHx8uJI=",
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
@@ -880,7 +880,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "events": {
@@ -1182,7 +1182,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -1314,7 +1314,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "html-tags": {
@@ -1349,7 +1349,7 @@
     "ignore": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "integrity": "sha1-xOcVRV9gc6jX5drnLS/J1xZj26Y=",
       "dev": true
     },
     "imurmurhash": {
@@ -1611,7 +1611,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -1690,7 +1690,7 @@
     "known-css-properties": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.3.0.tgz",
-      "integrity": "sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==",
+      "integrity": "sha1-o9E1u/xg7oxurPL35+by1HVeSaQ=",
       "dev": true
     },
     "lazy-cache": {
@@ -1829,7 +1829,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -1930,7 +1930,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -2110,7 +2110,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -2152,7 +2152,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
@@ -2546,7 +2546,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -2806,7 +2806,7 @@
     "postcss-reporter": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
-      "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
+      "integrity": "sha1-oUF3/RNCgp0pFlPyeG79ZxEDMsM=",
       "dev": true,
       "requires": {
         "chalk": "2.1.0",
@@ -2979,7 +2979,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -3058,7 +3058,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -3095,7 +3095,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
@@ -3204,7 +3204,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -3288,7 +3288,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "sass-graph": {
@@ -3333,7 +3333,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "set-blocking": {
@@ -3478,7 +3478,7 @@
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -3491,7 +3491,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -3518,7 +3518,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -3586,7 +3586,7 @@
     "stylelint": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-8.1.1.tgz",
-      "integrity": "sha512-RtjUtqG2h3dP4CuMU1M++GRJGvKXWozmv5yhLoOLy7NWP2jJZOwLZSVwtcjXQsBJBfGuC33mooBOwNaCIhi2tQ==",
+      "integrity": "sha1-n+7taZWYsnQncVVR7XeG2zQcGa0=",
       "dev": true,
       "requires": {
         "autoprefixer": "7.1.4",
@@ -3630,7 +3630,7 @@
         "autoprefixer": {
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.4.tgz",
-          "integrity": "sha512-MB1XybOJqu1uAwpfSilAa1wSURNc4W310CFKvMj1fNaJBFxr1PGgz72vZaPr9ryKGqs2vYZ6jDyJ0aiGELjsoA==",
+          "integrity": "sha1-lghH26pAFryOjlLsiRy/jxJXp0g=",
           "dev": true,
           "requires": {
             "browserslist": "2.4.0",
@@ -3646,13 +3646,13 @@
     "stylelint-config-recommended": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-1.0.0.tgz",
-      "integrity": "sha512-wp50rY5A6MWndIIkKNNzJv/S58lTvqQEriS7CXTBN1SwtoY/YjHhCLIOkjundLnUWMvJJska6GnciLbs76UQrA==",
+      "integrity": "sha1-dSwX/Gj6ZM1edYniT25G534UpzU=",
       "dev": true
     },
     "stylelint-config-recommended-scss": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-2.0.0.tgz",
-      "integrity": "sha512-DUIW3daRl5EAyU4ZR6xfPa+bqV5wDccS7X1je6Enes9edpbmWUBR/5XLfDPnjMJgqOe2QwqwaE/qnG4lXID9rg==",
+      "integrity": "sha1-P0SzOK+zv1tr2e663UaO7ydxOSI=",
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "1.0.0"
@@ -3661,7 +3661,7 @@
     "stylelint-config-standard": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-17.0.0.tgz",
-      "integrity": "sha512-G8jMZ0KsaVH7leur9XLZVhwOBHZ2vdbuJV8Bgy0ta7/PpBhEHo6fjVDaNchyCGXB5sRcWVq6O9rEU/MvY9cQDQ==",
+      "integrity": "sha1-QhA6CQBU7io93p7K7VXl1NnQWfw=",
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "1.0.0"
@@ -3670,7 +3670,7 @@
     "stylelint-scss": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-2.1.0.tgz",
-      "integrity": "sha512-xlaN1tdMj3mlNtw1pAjbIQqThghU3e+XGyHwhyr/obtB0R+Vt9VF3F3oYaVawx1JAzW78CuDku/CkPlnrgmHZA==",
+      "integrity": "sha1-4/4kJivLCc9w2Fm4CxcJnVEQlN4=",
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
@@ -3692,7 +3692,7 @@
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
       "dev": true,
       "requires": {
         "has-flag": "2.0.0"
@@ -3766,7 +3766,7 @@
     "timers-browserify": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+      "integrity": "sha1-lspT9LeUpefA4b18yIo3Ipj6AeY=",
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
@@ -3925,7 +3925,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -4041,7 +4041,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -4056,7 +4056,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/edx-bootstrap",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "The Bootstrap theme for Open edX",
   "license": "Apache-2.0",
   "repository": {
@@ -14,7 +14,7 @@
   ],
   "homepage": "https://github.com/edx/edx-bootstrap#readme",
   "dependencies": {
-    "bootstrap": "v4.0.0-beta"
+    "bootstrap": "v4.0.0-beta.2"
   },
   "devDependencies": {
     "@edx/stylelint-config-edx": "^1.1.0",

--- a/sass/edx/_variables.scss
+++ b/sass/edx/_variables.scss
@@ -60,29 +60,38 @@ $colors: map-merge((
   gray-dark: $gray-800
 ), $colors);
 
+$primary:       $blue !default;
+$secondary:     $gray-800 !default;
+$inverse:       $white !default;
+$disabled:      $gray-600 !default;
+$success:       $green !default;
+$info:          $cyan !default;
+$warning:       $yellow !default;
+$danger:        $red !default;
+$purchase:      $green !default;
+$lightest:      $gray-100 !default;
+$light:         $gray-200 !default;
+$dark:          $gray-800 !default;
+$darker:        $gray-900 !default;
+$darkest:       $black !default;
+
 $theme-colors: () !default;
 $theme-colors: map-merge((
-  primary: $blue,
-  secondary: $gray-600,
-  inverse: $white,
-  disabled: $gray-600,
-  success: $green,
-  info: $pink,
-  warning: $yellow,
-  danger: $red,
-  purchase: $green,
-  lightest: $gray-100,
-  light: $gray-200,
-  dark: $gray-800,
-  darker: $gray-900,
-  darkest: $black
+  primary: $primary,
+  secondary: $secondary,
+  inverse: $inverse,
+  disabled: $disabled,
+  success: $success,
+  info: $info,
+  warning: $warning,
+  danger: $danger,
+  purchase: $purchase,
+  lightest: $lightest,
+  light: $light,
+  dark: $dark,
+  darker: $darker,
+  darkest: $darkest
 ), $theme-colors);
-
-// Set specific theme colors for use in functions
-$theme-color-primary: theme-color("primary");
-$theme-color-inverse: theme-color("inverse");
-$theme-color-darker: theme-color("darker");
-$theme-color-darkest: theme-color("darkest");
 
 // Set a specific jump point for requesting color jumps
 $theme-color-interval: 8% !default;
@@ -92,6 +101,7 @@ $theme-color-interval: 8% !default;
 //
 // Quickly modify global styling by enabling or disabling optional features.
 
+//$enable-caret:              true !default;
 //$enable-rounded:            true !default;
 //$enable-shadows:            false !default;
 //$enable-gradients:          false !default;
@@ -136,10 +146,10 @@ $body-color:    theme-color("dark") !default;
 //
 // Style anchor elements.
 
-$link-color:            theme-color("primary") !default;
-$link-decoration:       none !default;
-$link-hover-color:      darken($link-color, 15%) !default;
-$link-hover-decoration: underline !default;
+//$link-color:            theme-color("primary") !default;
+//$link-decoration:       none !default;
+//$link-hover-color:      darken($link-color, 15%) !default;
+//$link-hover-decoration: underline !default;
 
 // Paragraphs
 //
@@ -153,30 +163,30 @@ $paragraph-margin-bottom: 1rem !default;
 // Define the minimum dimensions at which your layout will change,
 // adapting to different screen sizes, for use in media queries.
 
-$grid-breakpoints: (
-  xs: 0,
-  sm: 576px,
-  md: 768px,
-  lg: 992px,
-  xl: 1200px
-) !default;
-
-@include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
-@include _assert-starts-at-zero($grid-breakpoints);
+//$grid-breakpoints: (
+//  xs: 0,
+//  sm: 576px,
+//  md: 768px,
+//  lg: 992px,
+//  xl: 1200px
+//) !default;
+//
+//@include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
+//@include _assert-starts-at-zero($grid-breakpoints);
 
 
 // Grid containers
 //
 // Define the maximum width of `.container` for different screen sizes.
 
-$container-max-widths: (
-  sm: 540px,
-  md: 720px,
-  lg: 960px,
-  xl: 1140px
-) !default;
-
-@include _assert-ascending($container-max-widths, "$container-max-widths");
+//$container-max-widths: (
+//  sm: 540px,
+//  md: 720px,
+//  lg: 960px,
+//  xl: 1140px
+//) !default;
+//
+//@include _assert-ascending($container-max-widths, "$container-max-widths");
 
 
 // Grid columns
@@ -223,11 +233,11 @@ $font-size-lg:   1.25rem !default;
 $font-size-sm:   0.875rem !default;
 
 $font-weight-light: 300 !default;
-$font-weight-normal: normal !default;
-$font-weight-bold: bold !default;
+$font-weight-normal: 400 !default;
+$font-weight-bold: 700 !default;
 
-$font-weight-base: $font-weight-normal !default;
-$line-height-base: 1.5 !default;
+//$font-weight-base: $font-weight-normal !default;
+//$line-height-base: 1.5 !default;
 
 $h1-font-size: 1.75rem !default;
 $h2-font-size: 1.5rem !default;
@@ -239,27 +249,27 @@ $h6-font-size: 0.75rem !default;
 //$headings-margin-bottom: ($spacer / 2) !default;
 //$headings-font-family:   inherit !default;
 //$headings-font-weight:   500 !default;
-//$headings-line-height:   1.1 !default;
+//$headings-line-height:   1.2 !default;
 //$headings-color:         inherit !default;
-//
+
 //$display1-size: 6rem !default;
 //$display2-size: 5.5rem !default;
 //$display3-size: 4.5rem !default;
 //$display4-size: 3.5rem !default;
-//
+
 //$display1-weight:     300 !default;
 //$display2-weight:     300 !default;
 //$display3-weight:     300 !default;
 //$display4-weight:     300 !default;
 //$display-line-height: $headings-line-height !default;
-//
+
 //$lead-font-size:   1.25rem !default;
 //$lead-font-weight: 300 !default;
-//
+
 //$small-font-size: 80% !default;
-//
-//$text-muted: $gray-600 !default;
-//
+
+$text-muted: theme-color("disabled") !default;
+
 //$blockquote-small-color:  $gray-600 !default;
 //$blockquote-font-size:    ($font-size-base * 1.25) !default;
 //
@@ -276,12 +286,12 @@ $h6-font-size: 0.75rem !default;
 //$list-inline-padding: 5px !default;
 //
 //$mark-bg: #fcf8e3 !default;
-//
-//
+
+
 // Tables
 //
 // Customizes the `.table` component with basic values, each used across all table variations.
-//
+
 //$table-cell-padding:            0.75rem !default;
 //$table-cell-padding-sm:         0.3rem !default;
 //
@@ -311,29 +321,32 @@ $input-btn-padding-y:       0.625rem !default;
 $input-btn-padding-x:       0.625rem !default;
 $input-btn-line-height:     1.25 !default;
 
-$input-btn-padding-y-sm:    0.25rem !default;
-$input-btn-padding-x-sm:    0.5rem !default;
-$input-btn-line-height-sm:  1.5 !default;
+//$input-btn-focus-width:       0.2rem !default;
+//$input-btn-focus-color:       rgba(theme-color("primary"), 0.25) !default;
+//$input-btn-focus-box-shadow:  0 0 0 $input-btn-focus-width $input-btn-focus-color !default;
 
-$input-btn-padding-y-lg:    0.5rem !default;
-$input-btn-padding-x-lg:    1rem !default;
-$input-btn-line-height-lg:  1.5 !default;
+//$input-btn-padding-y-sm:    0.25rem !default;
+//$input-btn-padding-x-sm:    0.5rem !default;
+//$input-btn-line-height-sm:  $line-height-sm !default;
+
+//$input-btn-padding-y-lg:    0.5rem !default;
+//$input-btn-padding-x-lg:    1rem !default;
+//$input-btn-line-height-lg:  $line-height-lg !default;
 
 $btn-font-weight:                $font-weight-normal !default;
-$btn-box-shadow:                 inset 0 1px 0 rgba($theme-color-inverse, 0.15), 0 1px 1px rgba($theme-color-darkest, 0.075) !default;
-$btn-focus-box-shadow:           0 0 0 3px rgba($theme-color-primary, 0.25) !default;
-$btn-active-box-shadow:          inset 0 3px 5px rgba($theme-color-darkest, 0.125) !default;
+$btn-box-shadow:                 inset 0 1px 0 rgba($inverse, 0.15), 0 1px 1px rgba($darkest, 0.075) !default;
+$btn-active-box-shadow:          inset 0 3px 5px rgba($darkest, 0.125) !default;
 
 $btn-link-disabled-color:        theme-colors("disabled") !default;
 
 $btn-block-spacing-y:            0.5rem !default;
 
 // Allows for customizing button radius independently from global border radius
-$btn-border-radius:              $border-radius !default;
-$btn-border-radius-lg:           $border-radius-lg !default;
-$btn-border-radius-sm:           $border-radius-sm !default;
+//$btn-border-radius:              $border-radius !default;
+//$btn-border-radius-lg:           $border-radius-lg !default;
+//$btn-border-radius-sm:           $border-radius-sm !default;
 
-$btn-transition:                 background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out !default;
+//$btn-transition:                 background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out !default;
 
 
 // Forms
@@ -342,9 +355,9 @@ $input-bg:                       theme-color("inverse") !default;
 $input-disabled-bg:              theme-color("light") !default;
 
 $input-color:                    theme-color("secondary") !default;
-$input-border-color:             rgba($theme-color-darkest, 0.15) !default;
+$input-border-color:             rgba($darkest, 0.15) !default;
 $input-btn-border-width:         $border-width !default; // For form controls and buttons
-$input-box-shadow:               inset 0 1px 1px rgba($theme-color-darkest, 0.075) !default;
+$input-box-shadow:               inset 0 1px 1px rgba($darkest, 0.075) !default;
 
 $input-border-radius:            $border-radius !default;
 $input-border-radius-lg:         $border-radius-lg !default;
@@ -352,7 +365,6 @@ $input-border-radius-sm:         $border-radius-sm !default;
 
 //$input-focus-bg:                 $input-bg !default;
 //$input-focus-border-color:       lighten($blue, 25%) !default;
-//$input-focus-box-shadow:         $input-box-shadow, $btn-focus-box-shadow !default;
 //$input-focus-color:              $input-color !default;
 //
 //$input-placeholder-color:        $gray-600 !default;
@@ -384,7 +396,6 @@ $input-border-radius-sm:         $border-radius-sm !default;
 //$input-group-addon-color:        $input-color !default;
 //$input-group-addon-bg:           $gray-200 !default;
 //$input-group-addon-border-color: $input-border-color !default;
-//$input-group-btn-border-color:   $input-border-color !default;
 //
 //$custom-control-gutter:   1.5rem !default;
 //$custom-control-spacer-y: 0.25rem !default;
@@ -479,13 +490,13 @@ $dropdown-min-width:             10rem !default;
 $dropdown-padding-y:             0.5rem !default;
 $dropdown-spacer:                0.125rem !default;
 $dropdown-bg:                    theme-color("inverse") !default;
-$dropdown-border-color:          rgba($theme-color-darkest, 0.15) !default;
+$dropdown-border-color:          rgba($darkest, 0.15) !default;
 $dropdown-border-width:          $border-width !default;
 $dropdown-divider-bg:            theme-color("light") !default;
-$dropdown-box-shadow:            0 0.5rem 1rem rgba($theme-color-darkest, 0.175) !default;
+$dropdown-box-shadow:            0 0.5rem 1rem rgba($darkest, 0.175) !default;
 
 $dropdown-link-color:            theme-color("darker") !default;
-$dropdown-link-hover-color:      darken($theme-color-darker, 5%) !default;
+$dropdown-link-hover-color:      darken($darker, 5%) !default;
 $dropdown-link-hover-bg:         theme-color("lightest") !default;
 
 $dropdown-link-active-color:     $component-active-color !default;
@@ -705,10 +716,12 @@ $nav-tabs-link-hover-border-color:              theme-color("light") !default;
 // Define alert colors, border radius, and padding.
 
 //$alert-padding-y:             0.75rem !default;
-//$alert-margin-bottom:         $spacer-y !default;
-$alert-border-radius:         1px !default;
+//$alert-padding-x:             1.25rem !default;
+//$alert-margin-bottom:         1rem !default;
+$alert-border-radius:           1px !default;
 //$alert-link-font-weight:      $font-weight-bold !default;
 //$alert-border-width:          $border-width !default;
+
 
 // Progress bars
 
@@ -772,8 +785,8 @@ $breadcrumb-item-padding:       0.5rem !default;
 $breadcrumb-margin-bottom:      1rem !default;
 
 $breadcrumb-bg:                 transparent !default;
-$breadcrumb-divider-color:      $gray-500 !default;
-$breadcrumb-active-color:       $gray-500 !default;
+$breadcrumb-divider-color:      theme-color("secondary") !default;
+$breadcrumb-active-color:       theme-color("secondary") !default;
 $breadcrumb-divider:            ">" !default;
 
 
@@ -812,7 +825,7 @@ $close-text-shadow:           0 1px 0 theme-color("inverse") !default;
 //$code-padding-y:              0.2rem !default;
 //$code-padding-x:              0.4rem !default;
 //$code-color:                  #bd4147 !default;
-//$code-bg:                     gray-100 !default;
+//$code-bg:                     $gray-100 !default;
 
 //$kbd-color:                   $white !default;
 //$kbd-bg:                      $gray-900 !default;

--- a/sass/open-edx/_variables.scss
+++ b/sass/open-edx/_variables.scss
@@ -60,29 +60,38 @@ $colors: map-merge((
   gray-dark: $gray-800
 ), $colors);
 
+$primary:       $blue !default;
+$secondary:     $gray-800 !default;
+$inverse:       $white !default;
+$disabled:      $gray-600 !default;
+$success:       $green !default;
+$info:          $cyan !default;
+$warning:       $yellow !default;
+$danger:        $red !default;
+$purchase:      $green !default;
+$lightest:      $gray-100 !default;
+$light:         $gray-200 !default;
+$dark:          $gray-800 !default;
+$darker:        $gray-900 !default;
+$darkest:       $black !default;
+
 $theme-colors: () !default;
 $theme-colors: map-merge((
-  primary: $blue,
-  secondary: $gray-600,
-  inverse: $white,
-  disabled: $gray-600,
-  success: $green,
-  info: $pink,
-  warning: $yellow,
-  danger: $red,
-  purchase: $green,
-  lightest: $gray-100,
-  light: $gray-200,
-  dark: $gray-800,
-  darker: $gray-900,
-  darkest: $black
+  primary: $primary,
+  secondary: $secondary,
+  inverse: $inverse,
+  disabled: $disabled,
+  success: $success,
+  info: $info,
+  warning: $warning,
+  danger: $danger,
+  purchase: $purchase,
+  lightest: $lightest,
+  light: $light,
+  dark: $dark,
+  darker: $darker,
+  darkest: $darkest
 ), $theme-colors);
-
-// Set specific theme colors for use in functions
-$theme-color-primary: theme-color("primary");
-$theme-color-inverse: theme-color("inverse");
-$theme-color-darker: theme-color("darker");
-$theme-color-darkest: theme-color("darkest");
 
 // Set a specific jump point for requesting color jumps
 $theme-color-interval: 8% !default;
@@ -92,6 +101,7 @@ $theme-color-interval: 8% !default;
 //
 // Quickly modify global styling by enabling or disabling optional features.
 
+//$enable-caret:              true !default;
 //$enable-rounded:            true !default;
 //$enable-shadows:            false !default;
 //$enable-gradients:          false !default;
@@ -136,10 +146,10 @@ $body-color:    theme-color("dark") !default;
 //
 // Style anchor elements.
 
-$link-color:            theme-color("primary") !default;
-$link-decoration:       none !default;
-$link-hover-color:      darken($link-color, 15%) !default;
-$link-hover-decoration: underline !default;
+//$link-color:            theme-color("primary") !default;
+//$link-decoration:       none !default;
+//$link-hover-color:      darken($link-color, 15%) !default;
+//$link-hover-decoration: underline !default;
 
 // Paragraphs
 //
@@ -153,30 +163,30 @@ $paragraph-margin-bottom: 1rem !default;
 // Define the minimum dimensions at which your layout will change,
 // adapting to different screen sizes, for use in media queries.
 
-$grid-breakpoints: (
-  xs: 0,
-  sm: 576px,
-  md: 768px,
-  lg: 992px,
-  xl: 1200px
-) !default;
-
-@include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
-@include _assert-starts-at-zero($grid-breakpoints);
+//$grid-breakpoints: (
+//  xs: 0,
+//  sm: 576px,
+//  md: 768px,
+//  lg: 992px,
+//  xl: 1200px
+//) !default;
+//
+//@include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
+//@include _assert-starts-at-zero($grid-breakpoints);
 
 
 // Grid containers
 //
 // Define the maximum width of `.container` for different screen sizes.
 
-$container-max-widths: (
-  sm: 540px,
-  md: 720px,
-  lg: 960px,
-  xl: 1140px
-) !default;
-
-@include _assert-ascending($container-max-widths, "$container-max-widths");
+//$container-max-widths: (
+//  sm: 540px,
+//  md: 720px,
+//  lg: 960px,
+//  xl: 1140px
+//) !default;
+//
+//@include _assert-ascending($container-max-widths, "$container-max-widths");
 
 
 // Grid columns
@@ -223,11 +233,11 @@ $font-size-lg:   1.25rem !default;
 $font-size-sm:   0.875rem !default;
 
 $font-weight-light: 300 !default;
-$font-weight-normal: normal !default;
-$font-weight-bold: bold !default;
+$font-weight-normal: 400 !default;
+$font-weight-bold: 700 !default;
 
-$font-weight-base: $font-weight-normal !default;
-$line-height-base: 1.5 !default;
+//$font-weight-base: $font-weight-normal !default;
+//$line-height-base: 1.5 !default;
 
 $h1-font-size: 1.75rem !default;
 $h2-font-size: 1.5rem !default;
@@ -239,27 +249,27 @@ $h6-font-size: 0.75rem !default;
 //$headings-margin-bottom: ($spacer / 2) !default;
 //$headings-font-family:   inherit !default;
 //$headings-font-weight:   500 !default;
-//$headings-line-height:   1.1 !default;
+//$headings-line-height:   1.2 !default;
 //$headings-color:         inherit !default;
-//
+
 //$display1-size: 6rem !default;
 //$display2-size: 5.5rem !default;
 //$display3-size: 4.5rem !default;
 //$display4-size: 3.5rem !default;
-//
+
 //$display1-weight:     300 !default;
 //$display2-weight:     300 !default;
 //$display3-weight:     300 !default;
 //$display4-weight:     300 !default;
 //$display-line-height: $headings-line-height !default;
-//
+
 //$lead-font-size:   1.25rem !default;
 //$lead-font-weight: 300 !default;
-//
+
 //$small-font-size: 80% !default;
-//
-//$text-muted: $gray-600 !default;
-//
+
+$text-muted: theme-color("disabled") !default;
+
 //$blockquote-small-color:  $gray-600 !default;
 //$blockquote-font-size:    ($font-size-base * 1.25) !default;
 //
@@ -276,12 +286,12 @@ $h6-font-size: 0.75rem !default;
 //$list-inline-padding: 5px !default;
 //
 //$mark-bg: #fcf8e3 !default;
-//
-//
+
+
 // Tables
 //
 // Customizes the `.table` component with basic values, each used across all table variations.
-//
+
 //$table-cell-padding:            0.75rem !default;
 //$table-cell-padding-sm:         0.3rem !default;
 //
@@ -311,29 +321,32 @@ $input-btn-padding-y:       0.625rem !default;
 $input-btn-padding-x:       0.625rem !default;
 $input-btn-line-height:     1.25 !default;
 
-$input-btn-padding-y-sm:    0.25rem !default;
-$input-btn-padding-x-sm:    0.5rem !default;
-$input-btn-line-height-sm:  1.5 !default;
+//$input-btn-focus-width:       0.2rem !default;
+//$input-btn-focus-color:       rgba(theme-color("primary"), 0.25) !default;
+//$input-btn-focus-box-shadow:  0 0 0 $input-btn-focus-width $input-btn-focus-color !default;
 
-$input-btn-padding-y-lg:    0.5rem !default;
-$input-btn-padding-x-lg:    1rem !default;
-$input-btn-line-height-lg:  1.5 !default;
+//$input-btn-padding-y-sm:    0.25rem !default;
+//$input-btn-padding-x-sm:    0.5rem !default;
+//$input-btn-line-height-sm:  $line-height-sm !default;
+
+//$input-btn-padding-y-lg:    0.5rem !default;
+//$input-btn-padding-x-lg:    1rem !default;
+//$input-btn-line-height-lg:  $line-height-lg !default;
 
 $btn-font-weight:                $font-weight-normal !default;
-$btn-box-shadow:                 inset 0 1px 0 rgba($theme-color-inverse, 0.15), 0 1px 1px rgba($theme-color-darkest, 0.075) !default;
-$btn-focus-box-shadow:           0 0 0 3px rgba($theme-color-primary, 0.25) !default;
-$btn-active-box-shadow:          inset 0 3px 5px rgba($theme-color-darkest, 0.125) !default;
+$btn-box-shadow:                 inset 0 1px 0 rgba($inverse, 0.15), 0 1px 1px rgba($darkest, 0.075) !default;
+$btn-active-box-shadow:          inset 0 3px 5px rgba($darkest, 0.125) !default;
 
 $btn-link-disabled-color:        theme-colors("disabled") !default;
 
 $btn-block-spacing-y:            0.5rem !default;
 
 // Allows for customizing button radius independently from global border radius
-$btn-border-radius:              $border-radius !default;
-$btn-border-radius-lg:           $border-radius-lg !default;
-$btn-border-radius-sm:           $border-radius-sm !default;
+//$btn-border-radius:              $border-radius !default;
+//$btn-border-radius-lg:           $border-radius-lg !default;
+//$btn-border-radius-sm:           $border-radius-sm !default;
 
-$btn-transition:                 background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out !default;
+//$btn-transition:                 background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out !default;
 
 
 // Forms
@@ -342,9 +355,9 @@ $input-bg:                       theme-color("inverse") !default;
 $input-disabled-bg:              theme-color("light") !default;
 
 $input-color:                    theme-color("secondary") !default;
-$input-border-color:             rgba($theme-color-darkest, 0.15) !default;
+$input-border-color:             rgba($darkest, 0.15) !default;
 $input-btn-border-width:         $border-width !default; // For form controls and buttons
-$input-box-shadow:               inset 0 1px 1px rgba($theme-color-darkest, 0.075) !default;
+$input-box-shadow:               inset 0 1px 1px rgba($darkest, 0.075) !default;
 
 $input-border-radius:            $border-radius !default;
 $input-border-radius-lg:         $border-radius-lg !default;
@@ -352,7 +365,6 @@ $input-border-radius-sm:         $border-radius-sm !default;
 
 //$input-focus-bg:                 $input-bg !default;
 //$input-focus-border-color:       lighten($blue, 25%) !default;
-//$input-focus-box-shadow:         $input-box-shadow, $btn-focus-box-shadow !default;
 //$input-focus-color:              $input-color !default;
 //
 //$input-placeholder-color:        $gray-600 !default;
@@ -384,7 +396,6 @@ $input-border-radius-sm:         $border-radius-sm !default;
 //$input-group-addon-color:        $input-color !default;
 //$input-group-addon-bg:           $gray-200 !default;
 //$input-group-addon-border-color: $input-border-color !default;
-//$input-group-btn-border-color:   $input-border-color !default;
 //
 //$custom-control-gutter:   1.5rem !default;
 //$custom-control-spacer-y: 0.25rem !default;
@@ -479,13 +490,13 @@ $dropdown-min-width:             10rem !default;
 $dropdown-padding-y:             0.5rem !default;
 $dropdown-spacer:                0.125rem !default;
 $dropdown-bg:                    theme-color("inverse") !default;
-$dropdown-border-color:          rgba($theme-color-darkest, 0.15) !default;
+$dropdown-border-color:          rgba($darkest, 0.15) !default;
 $dropdown-border-width:          $border-width !default;
 $dropdown-divider-bg:            theme-color("light") !default;
-$dropdown-box-shadow:            0 0.5rem 1rem rgba($theme-color-darkest, 0.175) !default;
+$dropdown-box-shadow:            0 0.5rem 1rem rgba($darkest, 0.175) !default;
 
 $dropdown-link-color:            theme-color("darker") !default;
-$dropdown-link-hover-color:      darken($theme-color-darker, 5%) !default;
+$dropdown-link-hover-color:      darken($darker, 5%) !default;
 $dropdown-link-hover-bg:         theme-color("lightest") !default;
 
 $dropdown-link-active-color:     $component-active-color !default;
@@ -639,20 +650,20 @@ $nav-tabs-link-hover-border-color:              theme-color("light") !default;
 //$popover-border-width:                $border-width !default;
 //$popover-border-color:                rgba($black,.2) !default;
 //$popover-box-shadow:                  0 5px 10px rgba($black,.2) !default;
-//
+
 //$popover-header-bg:                    darken($popover-bg, 3%) !default;
 //$popover-header-color:                 $headings-color !default;
 //$popover-header-padding-y:             8px !default;
 //$popover-header-padding-x:             14px !default;
-//
+
 //$popover-body-color:               $body-color !default;
 //$popover-body-padding-y:           9px !default;
 //$popover-body-padding-x:           14px !default;
-//
+
 //$popover-arrow-width:                 10px !default;
 //$popover-arrow-height:                5px !default;
 //$popover-arrow-color:                 $popover-bg !default;
-//
+
 //$popover-arrow-outer-width:           ($popover-arrow-width + 1px) !default;
 //$popover-arrow-outer-color:           fade-in($popover-border-color, 0.05) !default;
 
@@ -663,7 +674,7 @@ $nav-tabs-link-hover-border-color:              theme-color("light") !default;
 //$badge-font-weight:           $font-weight-bold !default;
 //$badge-padding-y:             0.25em !default;
 //$badge-padding-x:             0.4em !default;
-//
+
 //$badge-pill-padding-x:        0.6em !default;
 // Use a higher than normal value to ensure completely rounded edges when
 // customizing padding or font-size on labels.
@@ -705,10 +716,12 @@ $nav-tabs-link-hover-border-color:              theme-color("light") !default;
 // Define alert colors, border radius, and padding.
 
 //$alert-padding-y:             0.75rem !default;
-//$alert-margin-bottom:         $spacer-y !default;
-$alert-border-radius:         1px !default;
+//$alert-padding-x:             1.25rem !default;
+//$alert-margin-bottom:         1rem !default;
+$alert-border-radius:           1px !default;
 //$alert-link-font-weight:      $font-weight-bold !default;
 //$alert-border-width:          $border-width !default;
+
 
 // Progress bars
 
@@ -731,7 +744,7 @@ $alert-border-radius:         1px !default;
 //$list-group-item-padding-y:      0.75rem !default;
 //$list-group-item-padding-x:      1.25rem !default;
 
-//$list-group-hover-bg:                 gray-100 !default;
+//$list-group-hover-bg:                 $gray-100 !default;
 //$list-group-active-color:             $component-active-color !default;
 //$list-group-active-bg:                $component-active-bg !default;
 //$list-group-active-border-color:      $list-group-active-bg !default;
@@ -772,8 +785,8 @@ $breadcrumb-item-padding:       0.5rem !default;
 $breadcrumb-margin-bottom:      1rem !default;
 
 $breadcrumb-bg:                 transparent !default;
-$breadcrumb-divider-color:      $gray-500 !default;
-$breadcrumb-active-color:       $gray-500 !default;
+$breadcrumb-divider-color:      theme-color("secondary") !default;
+$breadcrumb-active-color:       theme-color("secondary") !default;
 $breadcrumb-divider:            ">" !default;
 
 
@@ -812,7 +825,7 @@ $close-text-shadow:           0 1px 0 theme-color("inverse") !default;
 //$code-padding-y:              0.2rem !default;
 //$code-padding-x:              0.4rem !default;
 //$code-color:                  #bd4147 !default;
-//$code-bg:                     gray-100 !default;
+//$code-bg:                     $gray-100 !default;
 
 //$kbd-color:                   $white !default;
 //$kbd-bg:                      $gray-900 !default;


### PR DESCRIPTION
This change upgrades to Bootstrap beta.2. I went line-by-line through the variables file to mirror the new Bootstrap version.

Sandbox: http://ux-test.edx.org/andya/beta-2-upgrade/