### PR TITLE
Upgrade to Bootstrap v4.0.0. Bump to 1.0.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/edx-bootstrap",
-  "version": "0.4.3",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -361,9 +361,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.2.tgz",
-      "integrity": "sha1-TWfSqiIZ8GLNkLwSR+Z0e56P0FE="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
+      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
     },
     "brace-expansion": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "homepage": "https://github.com/edx/edx-bootstrap#readme",
   "dependencies": {
-    "bootstrap": "v4.0.0",
+    "bootstrap": "4.0.0",
     "jquery": "^3.2.1",
     "popper.js": "^1.12.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/edx-bootstrap",
-  "version": "0.4.3",
+  "version": "1.0.0",
   "description": "The Bootstrap theme for Open edX",
   "license": "Apache-2.0",
   "repository": {
@@ -14,7 +14,7 @@
   ],
   "homepage": "https://github.com/edx/edx-bootstrap#readme",
   "dependencies": {
-    "bootstrap": "v4.0.0-beta.2",
+    "bootstrap": "v4.0.0",
     "jquery": "^3.2.1",
     "popper.js": "^1.12.6"
   },

--- a/sass/_legacy-reset.scss
+++ b/sass/_legacy-reset.scss
@@ -6,7 +6,7 @@
 // To use, include this reset before all other Bootstrap references
 // within the consuming application or package's pipeline.
 
-@import "~bootstrap/scss/bootstrap-reboot";
+@import "~bootstrap/scss/reboot";
 @import "edx/_theme";
 
 // The Open edX platform's legacy base font size is 62.5%. This
@@ -43,21 +43,18 @@ $input-btn-padding-y-sm: $input-btn-padding-y-sm / $base-rem-size;
 $input-btn-padding-x-lg: $input-btn-padding-x-lg / $base-rem-size;
 $input-btn-padding-y-lg: $input-btn-padding-y-lg / $base-rem-size;
 $form-text-margin-top: $form-text-margin-top / $base-rem-size;
-$form-check-margin-bottom: $form-check-margin-bottom / $base-rem-size;
 $form-check-input-gutter: $form-check-input-gutter / $base-rem-size;
 $form-check-input-margin-y: $form-check-input-margin-y / $base-rem-size;
 $form-check-input-margin-x: $form-check-input-margin-x / $base-rem-size;
 $form-check-inline-margin-x: $form-check-inline-margin-x / $base-rem-size;
 $custom-control-gutter: $custom-control-gutter / $base-rem-size;
 $custom-control-spacer-x: $custom-control-spacer-x / $base-rem-size;
-$custom-control-spacer-y: $custom-control-spacer-y / $base-rem-size;
 $custom-control-indicator-size: $custom-control-indicator-size / $base-rem-size;
 $custom-control-indicator-box-shadow: $custom-control-indicator-box-shadow / $base-rem-size;
 $custom-select-padding-x: $custom-select-padding-x / $base-rem-size;
 $custom-select-padding-y: $custom-select-padding-y / $base-rem-size;
 $custom-select-indicator-padding: $custom-select-indicator-padding / $base-rem-size;
 $custom-file-height: $custom-file-height / $base-rem-size;
-$custom-file-width: $custom-file-width / $base-rem-size;
 $custom-file-focus-box-shadow: $custom-file-focus-box-shadow / $base-rem-size;
 $custom-file-padding-x: $custom-file-padding-x / $base-rem-size;
 $custom-file-padding-y: $custom-file-padding-y / $base-rem-size;
@@ -94,5 +91,5 @@ $thumbnail-padding: $thumbnail-padding / $base-rem-size;
 $breadcrumb-padding-y: $breadcrumb-padding-y / $base-rem-size;
 $breadcrumb-padding-x: $breadcrumb-padding-x / $base-rem-size;
 $breadcrumb-item-padding: $breadcrumb-item-padding / $base-rem-size;
-$code-padding-x: $code-padding-x / $base-rem-size;
-$code-padding-y: $code-padding-y / $base-rem-size;
+$kbd-padding-x: $code-padding-x / $base-rem-size;
+$kbd-padding-y: $code-padding-y / $base-rem-size;


### PR DESCRIPTION
See Bootstrap 4 changelog for breaking changes between `v4.0.0-beta.2` and `v4.0.0`: https://github.com/twbs/bootstrap/releases. I made this the 1.0.0 release because of the breaking changes.

@edx/fedx-team 