### PR TITLE
feat: remove fonts to allow for performance improvement

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet">
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"

--- a/scss/edx/_fonts.scss
+++ b/scss/edx/_fonts.scss
@@ -1,1 +1,0 @@
-@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500,700');

--- a/scss/edx/theme.scss
+++ b/scss/edx/theme.scss
@@ -1,4 +1,3 @@
-@import "fonts";
 @import "~bootstrap/scss/functions";
 @import "functions";
 @import "variables";

--- a/scss/open-edx/_fonts.scss
+++ b/scss/open-edx/_fonts.scss
@@ -1,1 +1,0 @@
-@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500,700');

--- a/scss/open-edx/theme.scss
+++ b/scss/open-edx/theme.scss
@@ -1,4 +1,3 @@
-@import "fonts";
 @import "~bootstrap/scss/functions";
 @import "variables";
 @import "../core/core";


### PR DESCRIPTION
By removing font imports from css we can include them more efficiently via a link tag.